### PR TITLE
chore: improve struct names

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ import (
 )
 
 func main() {
-	commandRunner := &commands.DefaultRunner{}
-	environmentGetter := &environment.DefaultEnvironment{}
-	logger := commands.NewLogger(commandRunner)
-	hookName := environment.JujuHookName(environmentGetter)
+	hookCommand := &commands.HookCommand{}
+	execEnv := &environment.ExecutionEnvironment{}
+	logger := commands.NewLogger(hookCommand)
+	hookName := environment.JujuHookName(execEnv)
 	logger.Info("Hook name:", hookName)
-	err := commands.StatusSet(commandRunner, commands.StatusActive)
+	err := commands.StatusSet(hookCommand, commands.StatusActive)
 	if err != nil {
 		logger.Error("Could not set status:", err.Error())
 		os.Exit(0)
@@ -54,6 +54,8 @@ func main() {
 	os.Exit(0)
 }
 ```
+
+You can find an example of the library in the [certificates charm](https://github.com/gruyaume/certificates-operator) repository. 
 
 ## Design principles
 

--- a/commands/exec.go
+++ b/commands/exec.go
@@ -10,9 +10,9 @@ type CommandRunner interface {
 	Run(name string, args ...string) ([]byte, error)
 }
 
-type DefaultRunner struct{}
+type HookCommand struct{}
 
-func (r *DefaultRunner) Run(name string, args ...string) ([]byte, error) {
+func (r *HookCommand) Run(name string, args ...string) ([]byte, error) {
 	cmd := exec.Command(name, args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/environment/get_env.go
+++ b/environment/get_env.go
@@ -6,8 +6,8 @@ type EnvironmentGetter interface {
 	Get(name string) string
 }
 
-type DefaultEnvironment struct{}
+type ExecutionEnvironment struct{}
 
-func (r *DefaultEnvironment) Get(name string) string {
+func (r *ExecutionEnvironment) Get(name string) string {
 	return os.Getenv(name)
 }


### PR DESCRIPTION
# Description

Improve struct names:
- `DefaultRunner` -> `HookCommand`
- `DefaultEnvironment` -> `ExecutionEnvironment`

Add reference to charm that uses this lib:
- https://github.com/gruyaume/certificates-operator

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
